### PR TITLE
workaround for stdbool.h missing in VS2008

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,6 +3,12 @@ set LIB=%LIBRARY_LIB%;%LIB%
 set LIBPATH=%LIBRARY_LIB%;%LIBPATH%
 set INCLUDE=%LIBRARY_INC%;%INCLUDE%
 
+:: VS2008 doesn't have stdbool.h so copy in our own
+:: to 'lib' where the other headers are so it gets picked up.
+if "%VS_MAJOR%" == "9" (
+    copy %RECIPE_DIR%\stdbool.h lib\
+)
+
 cmake -G "NMake Makefiles" ^
       -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
       -D CMAKE_BUILD_TYPE=Release ^

--- a/recipe/stdbool.h
+++ b/recipe/stdbool.h
@@ -1,0 +1,3 @@
+typedef int bool;
+#define false 0
+#define true 1


### PR DESCRIPTION
Maybe we need a `msbooltypes` package for this if it becomes a common problem? Anyway, this seems to fix the build for me.